### PR TITLE
Implemented feature of displaying date according to users timezone in logs. 

### DIFF
--- a/src/auditlog/mixins.py
+++ b/src/auditlog/mixins.py
@@ -30,7 +30,24 @@ class MiddlewareMixinclass(MiddlewareMixin):
     disp_remote_addr.short_description = "IP Address"
 
 class LogEntryAdminMixin(object):
+
+    #GOIP API used to get user location details.
+    headers = {
+        'accept': "application/json",
+        'content-type': "application/json"
+        }
+    response = requests.request("GET", settings.AUDITLOG_GOIP_API, headers=headers)
+    response_dict = json.loads(response.text)       #converting response to dictionary
+    tz_from_response = response_dict["time_zone"]
+
     def created(self, obj):
+        Audit_data = LogEntry.objects.all()
+        for audit_obj in Audit_data:
+            new_ts = audit_obj.timestamp.strftime("%m/%d/%Y %I:%M %p")
+            new_ts = audit_obj.timestamp.strptime(new_ts,"%m/%d/%Y %I:%M %p")
+            system_tz = pytz.timezone('UTC')
+            local_tz = pytz.timezone(LogEntryAdminMixin.tz_from_response)       #local tz set as timezone from response
+            local_ts = system_tz.localize(new_ts).astimezone(local_tz)      #returns datetime in the local timezone
         return obj.timestamp.strftime('%b. %d, %Y, %I:%M %p') #Displays date in diff format
     created.short_description = 'Date'
 


### PR DESCRIPTION
GEIOP (Free IP Geolocation) API is used to get user location details and convert date in logs to user's timezone.